### PR TITLE
Fixes to compile in Visual Studio 2015 Update 3

### DIFF
--- a/include/fruit/impl/component.defn.h
+++ b/include/fruit/impl/component.defn.h
@@ -33,17 +33,16 @@ namespace meta {
 template <typename... PreviousBindings>
 struct OpForComponent {
   template <typename Comp>
-  using ConvertTo = Eval<
-      Call(ReverseComposeFunctors(ComponentFunctor(ConvertComponent, Comp),
-                                  ProcessDeferredBindings,
-                                  Id<ProcessBinding(PreviousBindings)>...),
-          ConstructComponentImpl())>;
-  
+  using Component = Eval<Call(ReverseComposeFunctors(ComponentFunctor(ConvertComponent, Comp), ProcessDeferredBindings), ConstructComponentImpl())>;
+
+  template<typename Comp>
+  using ConvertTo = Eval<Call(Id<ProcessBinding(PreviousBindings)>..., Component<Comp>)>;
+
+  template<typename Binding>
+  using Process = Eval<Call(ProcessBinding(Binding), ConstructComponentImpl())>;
+
   template <typename Binding>
-  using AddBinding = Eval<
-      Call(ReverseComposeFunctors(ProcessBinding(Binding),
-                                  Id<ProcessBinding(PreviousBindings)>...),
-           ConstructComponentImpl())>;
+  using AddBinding = Eval<Call(Id<ProcessBinding(PreviousBindings)>..., Process<Binding>)>;
 };
 } // namespace meta
 } // namespace impl

--- a/include/fruit/impl/meta/component.h
+++ b/include/fruit/impl/meta/component.h
@@ -327,7 +327,8 @@ struct NumAssisted {
   
   template <typename... Types>
   struct apply<Vector<Types...>> {
-    using type = Int<staticSum(IsAssisted::apply<Types>::type::value...)>;
+    static constexpr int sum = staticSum(IsAssisted::apply<Types>::type::value...);
+    using type = Int<sum>;
   };
 };
 

--- a/include/fruit/impl/meta/eval.h
+++ b/include/fruit/impl/meta/eval.h
@@ -56,9 +56,10 @@ struct SimpleIsError<Error<ErrorTag, ErrorArgs...>> {
 
 template <typename MetaFun, typename... Params>
 struct DoEvalFun {
+  static constexpr bool error = staticOr<SimpleIsError<Params>::value...>();
   using type = 
       typename DoEval<typename 
-          std::conditional<staticOr<SimpleIsError<Params>::value...>(),
+          std::conditional<error,
                            ExtractFirstError, 
                            MetaFun>::type
       ::template apply<
@@ -98,9 +99,10 @@ struct DoEval<MetaFun(MetaExprs...)> {
   constexpr static bool static_warning() __attribute__((deprecated("static_warning"))) { return true; }
   static_assert(static_warning(), "");
 #endif
+  static constexpr bool error = staticOr<SimpleIsError<typename DoEval<MetaExprs>::type>::value...>();
   using type = 
       typename DoEval<typename 
-          std::conditional<staticOr<SimpleIsError<typename DoEval<MetaExprs>::type>::value...>(),
+          std::conditional<error,
                            ExtractFirstError, 
                            MetaFun>::type
       ::template apply<
@@ -116,9 +118,10 @@ struct DoEval<MetaFun(*)(MetaExprs...)> {
   constexpr static bool static_warning() __attribute__((deprecated("static_warning"))) { return true; }
   static_assert(static_warning(), "");
 #endif
+  static constexpr bool error = staticOr<SimpleIsError<typename DoEval<MetaExprs>::type>::value...>();
   using type = 
       typename DoEval<typename 
-          std::conditional<staticOr<SimpleIsError<typename DoEval<MetaExprs>::type>::value...>(),
+          std::conditional<error,
                            ExtractFirstError, 
                            MetaFun>::type
       ::template apply<


### PR DESCRIPTION
Got it compiling under Visual Studio by taking this stuff in account:
- the compiler gets confused about nested constexpr functions calls, had to separate them
- `typeid`  is not constexpr for some reason in Visual Studio 2015, consider using https://github.com/Manu343726/ctti