### PR TITLE
Fix main binary include directory.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ else()
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # (debug-only) compile switch to get deep template instantiation stacktraces for errors (instead
 # of the user-friendly default that hides Fruit internals).


### PR DESCRIPTION
Additional main include directory has to be based on CMAKE_CURRENT_BINARY_DIR
instead of CMAKE_BINARY_DIR to reflect subproject hierarchies.

Scenario:
my_app
| - CMakeLists.txt [ add_subdirectory(externals) ]
| - externals
    | - CMakeLists.txt [ add_subdirectory(fruit) ]
    | - fruit

In the build folder the hierarchy with externals/fruit/ is replicated
which is why we need CMAKE_CURRENT_BINARY_DIR instead of CMAKE_BINARY_DIR.