### PR TITLE
Fixed support for MSVC 14 (VS2015)

### DIFF
--- a/include/fruit/component.h
+++ b/include/fruit/component.h
@@ -55,7 +55,7 @@ class Component {
    * This is usually called implicitly when returning a component from a function. See PartialComponent for an example.
    */
   template<typename... Bindings>
-  Component(PartialComponent<Bindings...> component);
+  Component(PartialComponent<Bindings...>&& component);
 
  private:
   // Do not use. Use fruit::createComponent() instead.

--- a/include/fruit/impl/component_functors.defn.h
+++ b/include/fruit/impl/component_functors.defn.h
@@ -951,7 +951,7 @@ struct AutoRegisterFactoryHelper {
         void operator()(FixedSizeVector<ComponentStorageEntry>& entries) {
           using NakedC     = UnwrapType<Eval<C>>;
           auto provider = [](const UnwrapType<Eval<CFunctor>>& fun) {
-            return UnwrapType<Eval<IFunctor>>([=](UnwrapType<Args>... args) {
+            return UnwrapType<Eval<IFunctor>>([=](typename TypeUnwrapper<Args>::type... args) {
               NakedC* c = fun(args...).release();
               NakedI* i = static_cast<NakedI*>(c);
               return std::unique_ptr<NakedI>(i);
@@ -1014,7 +1014,7 @@ struct AutoRegisterFactoryHelper {
       using Result = Eval<GetResult(R)>;
       void operator()(FixedSizeVector<ComponentStorageEntry>& entries) {
         auto provider = [](const UnwrapType<Eval<CFunctor>>& fun) {
-          return UnwrapType<Eval<CUniquePtrFunctor>>([=](UnwrapType<Args>... args) {
+          return UnwrapType<Eval<CUniquePtrFunctor>>([=](typename TypeUnwrapper<Args>::type... args) {
             NakedC* c = new NakedC(fun(args...));
             return std::unique_ptr<NakedC>(c);
           });

--- a/include/fruit/impl/component_storage/partial_component_storage.defn.h
+++ b/include/fruit/impl/component_storage/partial_component_storage.defn.h
@@ -328,7 +328,7 @@ public:
       : previous_storage(previous_storage) {
   }
 
-  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) {
+  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) const {
     previous_storage.addBindings(entries);
   }
 
@@ -371,7 +371,7 @@ public:
         fun(fun1) {
   }
 
-  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) {
+  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) const {
     entries.push_back(ComponentStorageEntry::LazyComponentWithNoArgs::create(fun));
     previous_storage.addBindings(entries);
   }
@@ -423,7 +423,7 @@ public:
         fun(fun1) {
   }
 
-  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) {
+  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) const {
     entries.push_back(ComponentStorageEntry::LazyComponentWithNoArgs::createReplacedComponentEntry(fun));
     previous_storage.addBindings(entries);
   }
@@ -485,7 +485,7 @@ public:
         fun(fun1) {
   }
 
-  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) {
+  void addBindings(FixedSizeVector<ComponentStorageEntry>& entries) const {
     entries.push_back(ComponentStorageEntry::LazyComponentWithNoArgs::createReplacementComponentEntry(fun));
     previous_storage.addBindings(entries);
   }

--- a/include/fruit/impl/injector.defn.h
+++ b/include/fruit/impl/injector.defn.h
@@ -120,7 +120,7 @@ inline Injector<P...>::Injector(const NormalizedComponent<NormalizedComponentPar
 
 template <typename... P>
 template <typename T>
-inline Injector<P...>::RemoveAnnotations<T> Injector<P...>::get() {
+inline typename Injector<P...>::RemoveAnnotations<T> Injector<P...>::get() {
 
   using E = typename fruit::impl::meta::InjectorImplHelper<P...>::template CheckGet<T>::type;
   (void)typename fruit::impl::meta::CheckIfError<E>::type();

--- a/include/fruit/impl/injector/injector_storage.h
+++ b/include/fruit/impl/injector/injector_storage.h
@@ -50,6 +50,14 @@ public:
   using RemoveAnnotations = fruit::impl::meta::UnwrapType<fruit::impl::meta::Eval<
       fruit::impl::meta::RemoveAnnotations(fruit::impl::meta::Type<AnnotatedT>)
       >>;
+
+  // MSVC 14 has trouble specializing alias templates using expanded pack elements.
+  // This is a known issue: https://stackoverflow.com/questions/43411542/metaprogramming-failed-to-specialize-alias-template
+  // The workaround is just to use a struct directly.
+  template <typename AnnotatedT>
+  struct AnnotationRemover {
+    using type = RemoveAnnotations<AnnotatedT>;
+  };
   
   template <typename T>
   using NormalizeType = fruit::impl::meta::UnwrapType<fruit::impl::meta::Eval<

--- a/include/fruit/impl/meta/basics.h
+++ b/include/fruit/impl/meta/basics.h
@@ -72,6 +72,15 @@ struct Call {
 template <typename WrappedType>
 using UnwrapType = typename WrappedType::type;
 
+// MSVC 14 has trouble specializing alias templates using expanded pack elements.
+// This is a known issue: https://stackoverflow.com/questions/43411542/metaprogramming-failed-to-specialize-alias-template
+// The workaround is just to use a struct directly.
+// typename TypeUnwrapper<Type<T>>::type is T.
+template <typename WrappedType>
+struct TypeUnwrapper {
+	using type = UnwrapType<WrappedType>;
+};
+
 // Logical And with short-circuit evaluation.
 struct And {
   template <typename... MetaExprs>

--- a/include/fruit/impl/meta/errors.h
+++ b/include/fruit/impl/meta/errors.h
@@ -42,7 +42,7 @@ struct ConstructError {
 #ifdef FRUIT_DEEP_TEMPLATE_INSTANTIATION_STACKTRACES_FOR_ERRORS
     static_assert(true || sizeof(typename CheckIfError<Error<ErrorTag, UnwrapType<Args>...>>::type), "");
 #endif
-    using type = Error<ErrorTag, UnwrapType<Args>...>;
+    using type = Error<ErrorTag, typename TypeUnwrapper<Args>::type...>;
   };
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,16 @@ else()
   set(FRUIT_ENABLE_COVERAGE_PYTHON_BOOL "False")
 endif()
 
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(MSVC)$")
+  # These warnings are disabled for tests only, since they can only be produced when using fruit as a client. Also, they cannot be disabled via pragma pushes/pops,
+  #   so we leave it up to clients to disable them if desired.
+  # The warning C4702 is disabled because if MSVC optimizes the call to InvokeLambdaWithInjectedArgVector::operator() when cPtr is null, it will inline
+  #   a FRUIT_UNREACHABLE statement, which makes all statements succeeding the operator() call unreachable.
+  # The warning C4503 is disabled because some of the test_class_destruction.py tests suchs as "test_injector_creation_and_injection"
+  #   produce extremely long decorator names. This has no effect on the actual results of the test.
+  set(FRUIT_TESTONLY_CXXFLAGS "${FRUIT_TESTONLY_CXXFLAGS} /wd4702 /wd4503")
+endif()
+
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/fruit_test_config.py"
      CONTENT "
 CXX='${CMAKE_CXX_COMPILER}'


### PR DESCRIPTION
The primary modes of failure (both compilation and runtime) for MSVC 14
were the following:
1. MSVC 14 is not able to properly parse alias
   template specializations when expanded parameter pack elements are
   used as a template argument.
2. MSVC 14 has trouble in some instances recognizing that a specialized
   alias template is a type.
3. Assuming struct Y inherits from struct X and y is an instance of Y,
   the pointer to y that is used for binding can get mangled when creating
   a Component.
   For example, fruit::createComponent().bindInstance<Y, Y>(y).bind<X, Y>()
   will mangle the pointer to y such that fruit::Injector::get() returns
   an invalid reference, causing a crash.
   I'm not exactly sure what the compiler is doing, but this happens
   when the PartialComponent returned by the chained binds calls is copied
   when it is passed by value to the Component constructor.
   Note, this does not happen if the bind calls in the above example
   are swapped:
      fruit::createComponent().bind<X, Y>().bindInstance<Y, Y>(y)

All examples compile and all tests run successfully on Windows.