### PR TITLE
Remove unnecessary copies for conanfile.py

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -74,13 +74,6 @@ conan_basic_setup()''')
 
         self.copy("COPYING", dst="licenses", ignore_case=True, keep_path=False,
                   src=self._source_subfolder)
-        self.copy("*.h", dst="include",
-                  src=os.path.join(self._source_subfolder, "include"))
-        self.copy("*fruit.lib", dst="lib", keep_path=False)
-        self.copy("*.dll", dst="bin", keep_path=False)
-        self.copy("*.so", dst="lib", keep_path=False)
-        self.copy("*.dylib", dst="lib", keep_path=False)
-        self.copy("*.a", dst="lib", keep_path=False)
 
     def package_info(self):
         self.cpp_info.includedirs = ["include"]


### PR DESCRIPTION
When calling CMake from conan, the ‘CMAKE_INSTALL_PREFIX‘ (installation path) is set to `conanfile.package_folder`.
Since CMake installs the fruit header and library into `CMAKE_INSTALL_PREFIX`, don't need to copy again in `package` function.

> https://docs.conan.io/en/latest/reference/build_helpers/cmake.html#definitions