### PR TITLE
Use float comparison for Conan compiler min version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,15 +19,15 @@ class FruitConan(ConanFile):
 
     def configure(self):
         min_version = {
-            "gcc": "5",
-            "clang": "3.5",
-            "apple-clang": "7.3",
-            "Visual Studio": "14", # MSVC 2015
+            "gcc": 5,
+            "clang": 3.5,
+            "apple-clang": 7.3,
+            "Visual Studio": 14, # MSVC 2015
         }.get(str(self.settings.compiler))
         if not min_version:
             # Unknown minimum version, let's try going ahead with the build to see if it works.
             return
-        if str(self.settings.compiler.version) < min_version:
+        if float(str(self.settings.compiler.version)) < min_version:
             raise ConanException("%s %s is not supported, must be at least %s" % (self.settings.compiler,
                                                                                   self.settings.compiler.version,
                                                                                   min_version))


### PR DESCRIPTION
`conanfile.py` currently uses string comparisons when checking the minimum supported compiler version, this causes issues when the compiler version is higher than the minimum, but starts with a lower integer as the first character, as shown below:

```
fruit/3.4.0@google/stable: Downloaded recipe revision 0
ERROR: fruit/3.4.0@google/stable: Error in configure() method, line 29
	min_version))
	ConanException: apple-clang 10.0 is not supported, must be at least 7.3
```

This PR switches to a float comparision, which whilst not perfect for version comparisons, should be sufficient for the precision of the compiler version numbers used by Conan.