### PR TITLE
Set version argument of project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 
 project(Fruit VERSION 3.4.0 LANGUAGES CXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-project(Fruit)
 cmake_minimum_required(VERSION 2.8)
+
+project(Fruit VERSION 3.4.0 LANGUAGES CXX)
 
 if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
@@ -97,8 +98,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 set(INSTALL_INCLUDE_DIR include/fruit CACHE PATH "Installation directory for headers")
 set(INSTALL_LIBRARY_DIR lib CACHE PATH "Installation directory for libraries")
 
-set(FRUIT_VERSION "3.4.0")
-
 add_subdirectory(configuration)
 add_subdirectory(src)
 
@@ -120,8 +119,4 @@ install(DIRECTORY include/fruit/
 set(CPACK_PACKAGE_NAME "Fruit")
 set(CPACK_PACKAGE_VENDOR "Marco Poletti")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Fruit - Dependency Injection Framework For C++")
-string(REGEX REPLACE "([^.]*)\\.([^.]*)\\.([^.]*)" "\\1" CPACK_PACKAGE_VERSION_MAJOR "${FRUIT_VERSION}")
-string(REGEX REPLACE "([^.]*)\\.([^.]*)\\.([^.]*)" "\\2" CPACK_PACKAGE_VERSION_MINOR "${FRUIT_VERSION}")
-string(REGEX REPLACE "([^.]*)\\.([^.]*)\\.([^.]*)" "\\3" CPACK_PACKAGE_VERSION_PATCH "${FRUIT_VERSION}")
-set(CPACK_PACKAGE_VERSION "${FRUIT_VERSION}")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "Fruit")

--- a/extras/packaging/CMakeLists.txt
+++ b/extras/packaging/CMakeLists.txt
@@ -8,7 +8,7 @@ libfruit.install
 libfruit.spec
 )
 
-# This places configured files (build files with @FRUIT_VERSION@ replaced) in build/extras/packaging/built
+# This places configured files (build files with @Fruit_VERSION@ replaced) in build/extras/packaging/built
 
 foreach(F ${PACKAGING_FILES})
   configure_file(${F} built/${F} @ONLY)
@@ -16,9 +16,9 @@ endforeach(F)
 
 configure_file(PKGBUILD PKGBUILD-template @ONLY)
 
-add_custom_target(fruit-${FRUIT_VERSION}.tar.gz ALL
+add_custom_target(fruit-${Fruit_VERSION}.tar.gz ALL
                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/PKGBUILD-template
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../..
-                  COMMAND git archive -o ${CMAKE_CURRENT_BINARY_DIR}/built/fruit-${FRUIT_VERSION}.tar.gz --prefix=fruit-${FRUIT_VERSION}/ HEAD
-                  COMMAND md5sum ${CMAKE_CURRENT_BINARY_DIR}/built/fruit-${FRUIT_VERSION}.tar.gz | awk '{print $$1}' >${CMAKE_CURRENT_BINARY_DIR}/tarball-md5
+                  COMMAND git archive -o ${CMAKE_CURRENT_BINARY_DIR}/built/fruit-${Fruit_VERSION}.tar.gz --prefix=fruit-${Fruit_VERSION}/ HEAD
+                  COMMAND md5sum ${CMAKE_CURRENT_BINARY_DIR}/built/fruit-${Fruit_VERSION}.tar.gz | awk '{print $$1}' >${CMAKE_CURRENT_BINARY_DIR}/tarball-md5
                   COMMAND sed "\"s/.*md5sums.*/md5sums=(`cat" "${CMAKE_CURRENT_BINARY_DIR}/tarball-md5`)/\"" <${CMAKE_CURRENT_BINARY_DIR}/PKGBUILD-template >${CMAKE_CURRENT_BINARY_DIR}/built/PKGBUILD)

--- a/extras/packaging/PKGBUILD
+++ b/extras/packaging/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Marco Poletti <poletti.marco@gmail.com>
 pkgname=libfruit
-pkgver=@FRUIT_VERSION@
+pkgver=@Fruit_VERSION@
 pkgrel=0
 pkgdesc="Fruit is a dependency injection framework for C++."
 url="https://github.com/google/fruit"

--- a/extras/packaging/libfruit.dsc
+++ b/extras/packaging/libfruit.dsc
@@ -1,10 +1,10 @@
 Format: 1.0
 Source: libfruit
-Version: @FRUIT_VERSION@-0
+Version: @Fruit_VERSION@-0
 Binary: libfruit
 Maintainer: Marco Poletti <poletti.marco@gmail.com>
 Architecture: any
 Build-Depends: debhelper (>= 4.1.16), cmake, libboost-dev, gcc (>= 4:5.0.0)
 Files: 
- d57283ebb8157ae919762c58419353c8 133282 libfruit_@FRUIT_VERSION@.orig.tar.gz
- 2fecf324a32123b08cefc0f047bca5ee 63176 libfruit_@FRUIT_VERSION@-0.diff.tar.gz
+ d57283ebb8157ae919762c58419353c8 133282 libfruit_@Fruit_VERSION@.orig.tar.gz
+ 2fecf324a32123b08cefc0f047bca5ee 63176 libfruit_@Fruit_VERSION@-0.diff.tar.gz

--- a/extras/packaging/libfruit.spec
+++ b/extras/packaging/libfruit.spec
@@ -3,7 +3,7 @@
 #
 
 Name:           libfruit
-Version:        @FRUIT_VERSION@
+Version:        @Fruit_VERSION@
 Release:        0
 Summary:        Dependency Injection Framework For C++
 License:        Apache-2.0


### PR DESCRIPTION
`<PROJECT-NAME>_VERSION` variable is defined by specifying the `VERSION` argument of `project()`.
This version will automatically propagate to the `CPACK_PACKAGE_VERSION` variable and so on.