### PR TITLE
Remove extra target for conan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,16 +96,18 @@ include(GNUInstallDirs)
 add_subdirectory(configuration)
 add_subdirectory(src)
 
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-  # Do not exclude these from "make all" in debug mode, they must build.
-  add_subdirectory(examples)
-  add_subdirectory(tests)
-else()
-  add_subdirectory(examples EXCLUDE_FROM_ALL)
-  add_subdirectory(tests)
-endif()
+if(NOT "${FRUIT_IS_BEING_BUILT_BY_CONAN}")
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+    # Do not exclude these from "make all" in debug mode, they must build.
+    add_subdirectory(examples)
+    add_subdirectory(tests)
+  else()
+    add_subdirectory(examples EXCLUDE_FROM_ALL)
+    add_subdirectory(tests)
+  endif()
 
-add_subdirectory(extras EXCLUDE_FROM_ALL)
+  add_subdirectory(extras EXCLUDE_FROM_ALL)
+endif()
 
 install(DIRECTORY include/fruit/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fruit


### PR DESCRIPTION
CMake directories examples, tests, and extras do not need to be built because they are not installed by Conan.