### PR TITLE
Fix missing shared library on Windows OS

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -76,5 +76,4 @@ conan_basic_setup()''')
                   src=self._source_subfolder)
 
     def package_info(self):
-        self.cpp_info.includedirs = ["include"]
-        self.cpp_info.libs = ["fruit"]
+        self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
With the current `package_info()` method, Windows shared libraries are not placed properly in conan packages.

`conans.tools.collect_libs()`  enumerates all binaries installed by CMake.