### PR TITLE
Fix conan tools.replace_in_file() patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.2)
 
 project(Fruit VERSION 3.4.0 LANGUAGES CXX)
 
+set(FRUIT_IS_BEING_BUILT_BY_CONAN FALSE CACHE BOOL "This is set in Conan builds.")
+if("${FRUIT_IS_BEING_BUILT_BY_CONAN}")
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  conan_basic_setup()
+endif()
+
 if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
@@ -54,8 +60,6 @@ endif()
 set(FRUIT_USES_BOOST TRUE CACHE BOOL
         "Whether to use Boost (specifically, boost::unordered_set and boost::unordered_map).
         If this is false, Fruit will use std::unordered_set and std::unordered_map instead (however this causes injection to be a bit slower).")
-
-set(FRUIT_IS_BEING_BUILT_BY_CONAN FALSE CACHE BOOL "This is set in Conan builds.")
 
 if("${WIN32}" AND "${FRUIT_USES_BOOST}" AND NOT "${FRUIT_IS_BEING_BUILT_BY_CONAN}")
   set(BOOST_DIR "" CACHE PATH "The directory where the boost library is installed, e.g. C:\\boost\\boost_1_62_0.")

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,15 +40,6 @@ class FruitConan(ConanFile):
         tools.get("{0}/archive/v{1}.tar.gz".format(self.homepage, self.version))
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
-        # This small hack might be useful to guarantee proper /MT /MD linkage
-        # in MSVC if the packaged project doesn't have variables to set it
-        # properly
-        cmake_project = "project(Fruit VERSION %s LANGUAGES CXX)" % (self.version,)
-        tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              cmake_project,
-                              (cmake_project + '''
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()'''))
 
     def _configure_cmake(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,11 +43,12 @@ class FruitConan(ConanFile):
         # This small hack might be useful to guarantee proper /MT /MD linkage
         # in MSVC if the packaged project doesn't have variables to set it
         # properly
+        cmake_project = "project(Fruit VERSION %s LANGUAGES CXX)" % (self.version,)
         tools.replace_in_file(os.path.join(self._source_subfolder, "CMakeLists.txt"),
-                              "project(Fruit)",
-                              '''PROJECT(Myfruit)
+                              cmake_project,
+                              (cmake_project + '''
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()''')
+conan_basic_setup()'''))
 
     def _configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
I noticed that `tools.replace_in_file()` failed when trying to build the master branch with conan.
Patch must be updated.