### PR TITLE
Set CMAKE_CXX_STANDARD 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)
 endif()
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # CMake on OSX likes to see this set explicitly, otherwise it outputs a warning.
 set(CMAKE_MACOSX_RPATH 1)
 


### PR DESCRIPTION
gcc and clang are set to `-std=c++11` in` FRUIT_ADDITIONAL_COMPILE_FLAGS`, but MSVC is not set.

`CMAKE_CXX_STANDARD` is a CMake variable that specifies required C++ Standard features.