### PR TITLE
Fix FindFruit.cmake file

### DIFF
--- a/cmake-modules/FindFruit.cmake
+++ b/cmake-modules/FindFruit.cmake
@@ -2,23 +2,23 @@
 # set(ENV{FRUIT_INSTALLED_DIR} "/path/to/fruit/build")
 
 find_path(FRUIT_INCLUDE_DIR fruit.h
-    HINTS (
-        FRUIT_INSTALLED_DIR
-        /usr
-        /usr/local
-    )
-    PATH_SUFFIXES include/fruit include fruit
-)
+        HINTS (
+            ${FRUIT_INSTALLED_DIR}
+            /usr
+            /usr/local
+            )
+        PATH_SUFFIXES include/fruit
+        )
 
 find_library(FRUIT_LIBRARY
-  NAMES fruit
-  HINTS (
-      FRUIT_INSTALLED_DIR
-      /usr
-      /usr/local
-  )
-  PATH_SUFFIXES lib ${FRUIT_INSTALLED_DIR}
-)
+        NAMES fruit
+        HINTS (
+            ${FRUIT_INSTALLED_DIR}
+            /usr
+            /usr/local
+            )
+        PATH_SUFFIXES lib lib64
+        )
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(fruit DEFAULT_MSG FRUIT_LIBRARY FRUIT_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Fruit DEFAULT_MSG FRUIT_LIBRARY FRUIT_INCLUDE_DIR)


### PR DESCRIPTION
- The filename forces the module to be called `Fruit`. (Lower case
  letter as `fruit` makes warning during the configure step.)
- The FRUIT_INSTALLED_DIR is a good concept, but needs to annotated
  as CMake variable, otherwise it uses the string as is.
- The library prefix shall allow `lib64` since this is very common
  prefix in many distro. (Would be also nice to add the debian
  variants of `lib/i386-linux-gnu` or `lib/x86_64-linux-gnu`.)