### PR TITLE
Makes using Boost optional when using Bazel.

### DIFF
--- a/configuration/bazel/fruit/impl/fruit-config-base.h
+++ b/configuration/bazel/fruit/impl/fruit-config-base.h
@@ -51,7 +51,7 @@
 // Whether abi::__cxa_demangle() is available after including cxxabi.h.
 #define FRUIT_HAS_CXA_DEMANGLE 1
 
-#define FRUIT_USES_BOOST 1
+#define FRUIT_USES_BOOST 0
 
 #define FRUIT_HAS_ALWAYS_INLINE_ATTRIBUTE 1
 


### PR DESCRIPTION
Love the library!

Could you please consider making the Boost dependency optional? 
Any project that wishes to include Boost can explicitly specify the 
dependency and the rest who find it difficult to include Boost
can still use Fruit.

This compiles fine on Mac OS X without errors as well.

What do you think?