### PR TITLE
Add CMake "system includes" option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 
+option(FRUIT_USE_SYSTEM_INCLUDES "Silence warnings in Fruit headers by marking them as SYSTEM includes." OFF)
+
 set(FRUIT_ADDITIONAL_CXX_FLAGS "" CACHE STRING "Additional CXX compiler flags." FORCE)
 
 set(FRUIT_ADDITIONAL_COMPILE_FLAGS "${FRUIT_ADDITIONAL_CXX_FLAGS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ else()
     add_library(fruit STATIC ${FRUIT_SOURCES})
 endif()
 
+add_library(fruit::fruit ALIAS fruit)
+
 if(FRUIT_USE_SYSTEM_INCLUDES)
     set(FRUIT_INTERNAL_INCLUDE_WARNING_GUARD SYSTEM)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,15 @@ else()
     add_library(fruit STATIC ${FRUIT_SOURCES})
 endif()
 
-target_include_directories(fruit PUBLIC ${FRUIT_INCLUDE_DIRS})
+if(FRUIT_USE_SYSTEM_INCLUDES)
+    set(FRUIT_INTERNAL_INCLUDE_WARNING_GUARD SYSTEM)
+else()
+    set(FRUIT_INTERNAL_INCLUDE_WARNING_GUARD "")
+endif()
+
+target_include_directories(fruit
+    ${FRUIT_INTERNAL_INCLUDE_WARNING_GUARD}
+    PUBLIC ${FRUIT_INCLUDE_DIRS})
 target_compile_options(fruit PUBLIC ${FRUIT_ADDITIONAL_COMPILE_FLAGS})
 
 if(FRUIT_USES_BOOST)


### PR DESCRIPTION
This adds an option to suppress warnings originating in fruit headers by marking them as system includes, following Abseil's example here:
https://github.com/abseil/abseil-cpp/blob/3cb4988999d2f16e11d86f9921e9526486ef1960/CMake/AbseilHelpers.cmake#L29

Also adds a namespaced alias target as that's the preferred way to refer to imported targets:
https://cmake.org/cmake/help/v3.13/manual/cmake-packages.7.html#creating-packages